### PR TITLE
[v1.2.0] Adds optional argument :with_scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,29 @@ ReadableEnums gives you enum-like methods and validations!
 => [:status, "ending is not a valid status"]
 ```
 
-It also accepts optional arguments.
+
+## Optional Arguments
+
+`allow_nil`: allow nil values in your enum column
+
 ```
-  readable_enums :status, [:active, :inactive, :pending], allow_nil: true, if: :validate?
+  readable_enums :status, [:active, :inactive, :pending], allow_nil: true
+```
+
+`if`: only validate the string attribute if `method` returns true
+
+```
+  readable_enums :status, [:active, :inactive, :pending], if: :validate?
 
   def validate?
     ...
   end
 ```
 
-`allow_nil: true` will allow the string attribute to be nil
+`with_scopes`: prevent scopes from being setup for your enum values if you don't need them, or want to define them yourself
 
-`if: :method` will only validate the string attribute if `method` returns true
+```
+  readable_enums :status, [:active, :inactive, :pending], with_scopes: false
+
+  scope :active, -> { where(status: :active).sort_by(&:created_at) }
+```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ReadableEnums gives you enum-like methods and validations!
   readable_enums :status, [:active, :inactive, :pending], allow_nil: true
 ```
 
-`if`: only validate the string attribute if `method` returns true
+`if`: only validate the string attribute if the conditional returns true
 
 ```
   readable_enums :status, [:active, :inactive, :pending], if: :validate?

--- a/lib/readable_enums.rb
+++ b/lib/readable_enums.rb
@@ -10,7 +10,7 @@ module ReadableEnums
       values.each do |enum|
         define_method(:"#{enum}?") { send(name.to_s) == enum }
         define_method(:"#{enum}!") { update(name.to_s => enum) }
-        define_singleton_method(:"#{enum}") { where(name.to_s => enum) }
+        define_singleton_method(:"#{enum}") { where(name.to_s => enum) } unless args[:with_scopes] == false
       end
     end
   end

--- a/readable_enums.gemspec
+++ b/readable_enums.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'readable_enums'
-  s.version     = '1.1.0'
+  s.version     = '1.2.0'
   s.date        = '2017-11-15'
   s.summary     = 'Create readable enums in your database!'
   s.description = 'Validation and helper methods for string based enums in rails'


### PR DESCRIPTION
Adds the optional argument `with_scopes: false` to prevent enum scopes from being generated, allowing you to define them yourself in the model.