### PR TITLE
allow introspection of readable enums

### DIFF
--- a/lib/readable_enums.rb
+++ b/lib/readable_enums.rb
@@ -1,6 +1,10 @@
 module ReadableEnums
   extend ActiveSupport::Concern
 
+  included do
+    class_attribute(:defined_readable_enums, instance_writer: false, default: {})
+  end
+
   module ClassMethods
     def readable_enum(name, values, **args)
       validates_args = args.slice(:allow_nil, :if).compact
@@ -12,6 +16,8 @@ module ReadableEnums
         define_method(:"#{enum}!") { update(name.to_s => enum) }
         define_singleton_method(:"#{enum}") { where(name.to_s => enum) } unless args[:with_scopes] == false
       end
+
+      defined_readable_enums[name] = values
     end
   end
 end

--- a/readable_enums.gemspec
+++ b/readable_enums.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = 'readable_enums'
-  s.version     = '1.2.2'
+  s.version     = '1.3.0'
   s.date        = '2018-03-14'
   s.summary     = 'Create readable enums in your database!'
   s.description = 'Validation and helper methods for string based enums in rails'
-  s.authors     = ['Joy Smith', 'Raynor Kuang', 'Austin Fisher']
+  s.authors     = ['Joy Smith', 'Raynor Kuang', 'Austin Fisher', 'Willy Unterkoefler']
   s.files       = ['lib/readable_enums.rb']
   s.homepage    = 'http://rubygems.org/gems/readable_enums'
   s.license     = 'MIT'


### PR DESCRIPTION
Similar to how you can introspect Rails `enum`s with `Foo.defined_enums`, you should be able to do so with readable enums too with `Foo.defined_readable_enums`