### PR TITLE
[BIZ-7667] Adds new prefix, suffix and with_methods args

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ ReadableEnums gives you enum-like methods and validations!
 
 ## Optional Arguments
 
+#### allow_nil
 `allow_nil (default false)`: allow nil values in your enum column
 
 ```
   readable_enums :status, [:active, :inactive, :pending], allow_nil: true
 ```
 
+#### if
 `if (default true)`: only validate the string attribute if the conditional returns true
 
 ```
@@ -72,10 +74,70 @@ ReadableEnums gives you enum-like methods and validations!
   end
 ```
 
+#### with_scopes
 `with_scopes (default true)`: prevent scopes from being setup for your enum values if you don't need them, or want to define them yourself
 
 ```
   readable_enums :status, [:active, :inactive, :pending], with_scopes: false
 
   scope :active, -> { where(status: :active).sort_by(&:created_at) }
+```
+
+#### with_methods
+`with_methods (default true)`: prevent methods from being setup for your enum values if you don't need them or want to define them yourself
+
+```
+  readable_enums :status, [:active, :inactive, :pending], with_methods: false
+
+  def active?
+    status == 'active'
+  end
+```
+
+#### prefix
+`prefix (default nil)`: add a prefix to all generated method names
+
+When `true` is provided, the enums name will be added to the beginning of each generated method's name
+```
+  readable_enums :status, [:active, :inactive, :pending], prefix: true
+
+  # creates method names such as
+  def status_active?
+  def status_active!
+  def status_inactive?
+  ...
+```
+
+When any other value is provided, that value will be added to the beginning of each generated method's name
+```
+  readable_enums :status, [:active, :inactive, :pending], prefix: :example
+
+  # creates method names such as
+  def example_active?
+  def example_active!
+  def example_inactive?
+```
+
+#### suffix
+`suffix (default nil)`: add a suffix to all generated method names
+
+When `true` is provided, the enums name will be added to the end of each generated method's name
+```
+  readable_enums :status, [:active, :inactive, :pending], suffix: true
+
+  # creates method names such as
+  def active_status?
+  def active_status!
+  def inactive_status?
+  ...
+```
+
+When any other value is provided, that value will be added to the end of each generated method's name
+```
+  readable_enums :status, [:active, :inactive, :pending], suffix: :example
+
+  # creates method names such as
+  def active_example?
+  def active_example!
+  def inactive_example?
 ```

--- a/README.md
+++ b/README.md
@@ -141,3 +141,14 @@ When any other value is provided, that value will be added to the end of each ge
   def active_example!
   def inactive_example?
 ```
+
+#### combinations
+If you have a use case for it, `prefix` and `suffix` can be utilized together. 
+```
+  readable_enums :status, [:active, :inactive, :pending], prefix: true, suffix: :example
+
+  # creates method names such as
+  def status_active_example?
+  def status_active_example!
+  def status_inactive_example?
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ end
 Add enum-like behavior to any existing string attribute by using the readable_enums method.
 
 ```
-  readable_enums :status, [:active, :inactive, :pending]
+readable_enums :status, [:active, :inactive, :pending]
 ```
 
 ReadableEnums gives you enum-like methods and validations!
@@ -60,38 +60,38 @@ ReadableEnums gives you enum-like methods and validations!
 `allow_nil (default false)`: allow nil values in your enum column
 
 ```
-  readable_enums :status, [:active, :inactive, :pending], allow_nil: true
+readable_enums :status, [:active, :inactive, :pending], allow_nil: true
 ```
 
 #### if
 `if (default true)`: only validate the string attribute if the conditional returns true
 
 ```
-  readable_enums :status, [:active, :inactive, :pending], if: :validate?
+readable_enums :status, [:active, :inactive, :pending], if: :validate?
 
-  def validate?
-    ...
-  end
+def validate?
+  ...
+end
 ```
 
 #### with_scopes
 `with_scopes (default true)`: prevent scopes from being setup for your enum values if you don't need them, or want to define them yourself
 
 ```
-  readable_enums :status, [:active, :inactive, :pending], with_scopes: false
+readable_enums :status, [:active, :inactive, :pending], with_scopes: false
 
-  scope :active, -> { where(status: :active).sort_by(&:created_at) }
+scope :active, -> { where(status: :active).sort_by(&:created_at) }
 ```
 
 #### with_methods
 `with_methods (default true)`: prevent methods from being setup for your enum values if you don't need them or want to define them yourself
 
 ```
-  readable_enums :status, [:active, :inactive, :pending], with_methods: false
+readable_enums :status, [:active, :inactive, :pending], with_methods: false
 
-  def active?
-    status == 'active'
-  end
+def active?
+  status == 'active'
+end
 ```
 
 #### prefix
@@ -99,23 +99,22 @@ ReadableEnums gives you enum-like methods and validations!
 
 When `true` is provided, the enums name will be added to the beginning of each generated method's name
 ```
-  readable_enums :status, [:active, :inactive, :pending], prefix: true
+readable_enums :status, [:active, :inactive, :pending], prefix: true
 
-  # creates method names such as
-  def status_active?
-  def status_active!
-  def status_inactive?
-  ...
+# creates method names such as
+def status_active?
+def status_active!
+def status_inactive?
 ```
 
 When any other value is provided, that value will be added to the beginning of each generated method's name
 ```
-  readable_enums :status, [:active, :inactive, :pending], prefix: :example
+readable_enums :status, [:active, :inactive, :pending], prefix: :example
 
-  # creates method names such as
-  def example_active?
-  def example_active!
-  def example_inactive?
+# creates method names such as
+def example_active?
+def example_active!
+def example_inactive?
 ```
 
 #### suffix
@@ -123,32 +122,31 @@ When any other value is provided, that value will be added to the beginning of e
 
 When `true` is provided, the enums name will be added to the end of each generated method's name
 ```
-  readable_enums :status, [:active, :inactive, :pending], suffix: true
+readable_enums :status, [:active, :inactive, :pending], suffix: true
 
-  # creates method names such as
-  def active_status?
-  def active_status!
-  def inactive_status?
-  ...
+# creates method names such as
+def active_status?
+def active_status!
+def inactive_status?
 ```
 
 When any other value is provided, that value will be added to the end of each generated method's name
 ```
-  readable_enums :status, [:active, :inactive, :pending], suffix: :example
+readable_enums :status, [:active, :inactive, :pending], suffix: :example
 
-  # creates method names such as
-  def active_example?
-  def active_example!
-  def inactive_example?
+# creates method names such as
+def active_example?
+def active_example!
+def inactive_example?
 ```
 
 #### combinations
 If you have a use case for it, `prefix` and `suffix` can be utilized together. 
 ```
-  readable_enums :status, [:active, :inactive, :pending], prefix: true, suffix: :example
+readable_enums :status, [:active, :inactive, :pending], prefix: true, suffix: :example
 
-  # creates method names such as
-  def status_active_example?
-  def status_active_example!
-  def status_inactive_example?
+# creates method names such as
+def status_active_example?
+def status_active_example!
+def status_inactive_example?
 ```

--- a/lib/readable_enums.rb
+++ b/lib/readable_enums.rb
@@ -11,13 +11,24 @@ module ReadableEnums
 
       validates name.to_sym, inclusion: { in: values, message: "%{value} is not a valid #{name}" }, **validates_args
 
+      defined_values = []
+
       values.each do |enum|
-        define_method(:"#{enum}?") { send(name.to_s) == enum }
-        define_method(:"#{enum}!") { update(name.to_s => enum) }
+        unless args[:with_methods] == false
+          prefix = args[:prefix] == true ? "#{name}" : args[:prefix]
+          suffix = args[:suffix] == true ? "#{name}" : args[:suffix]
+          method_name = [prefix, enum, suffix].compact.join('_')
+
+          define_method(:"#{method_name}?") { send(name.to_s) == enum }
+          define_method(:"#{method_name}!") { update(name.to_s => enum) }
+
+          defined_values << method_name
+        end
+
         define_singleton_method(:"#{enum}") { where(name.to_s => enum) } unless args[:with_scopes] == false
       end
 
-      defined_readable_enums[name] = values
+      defined_readable_enums[name] = defined_values
     end
   end
 end

--- a/readable_enums.gemspec
+++ b/readable_enums.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = 'readable_enums'
-  s.version     = '1.3.0'
-  s.date        = '2018-03-14'
+  s.version     = '1.4.0'
+  s.date        = '2025-03-18'
   s.summary     = 'Create readable enums in your database!'
   s.description = 'Validation and helper methods for string based enums in rails'
-  s.authors     = ['Joy Smith', 'Raynor Kuang', 'Austin Fisher', 'Willy Unterkoefler']
+  s.authors     = ['Joy Smith', 'Raynor Kuang', 'Austin Fisher', 'Willy Unterkoefler', 'Neal Griffith']
   s.files       = ['lib/readable_enums.rb']
   s.homepage    = 'http://rubygems.org/gems/readable_enums'
   s.license     = 'MIT'


### PR DESCRIPTION
Adds 3 new options to readable enum declarations

1. suffix
2. prefix
These mirror the implementation in ActiveRecord::Enum: https://api.rubyonrails.org/classes/ActiveRecord/Enum.html

3. with_methods
This mirrors `with_scopes` implementation, to prevent any methods from being created

This also includes changes to support the sig generation for sorbet, ensuring that the correct method names are passed into `defined_readable_enums` and that if with_methods is false, then no method names are provided to it.

One of these will first be utilized in BIZ-7592: https://github.com/notarize/notarize-api/pull/18200 where I ran into the problem of 2 different enums having some of the same values between transaction_type and config_id leading to some methods being overwritten. 

Ultimately I plan to utilize `with_methods: false` for that PR, but I had considered the others for implementation, and they're so easy to add right now that I figured why not since I've wanted to use those before.